### PR TITLE
Fixed: base_uri does not set correctly

### DIFF
--- a/src/Client/Client.php
+++ b/src/Client/Client.php
@@ -22,7 +22,7 @@ class Client
     ) {
         $this->client = $client ?? new GuzzleClient(
             [
-                'base_uri' => $this->configProvider->baseUrl,
+                'base_uri' => rtrim($this->configProvider->baseUrl, '/') . '/',
             ]
         );
     }

--- a/src/Request/FindPointsRequest.php
+++ b/src/Request/FindPointsRequest.php
@@ -6,7 +6,7 @@ namespace Answear\InpostBundle\Request;
 
 class FindPointsRequest implements Request
 {
-    private const ENDPOINT = '/points';
+    private const ENDPOINT = 'points';
     private const HTTP_METHOD = 'GET';
 
     private array $searchCriteria;


### PR DESCRIPTION
We use the `base_uri` like: `https://api-shipx-pl.easypack24.net/v1`.
In result we have 404 Not Found for `/points` endpoint, because of: `https://api-shipx-pl.easypack24.net/points`

Docs:
https://docs.guzzlephp.org/en/stable/quickstart.html