### PR TITLE
NOISSUE - fix phpstan dep

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,6 @@
         "php": "^8.2",
         "ext-json": "*",
         "guzzlehttp/guzzle": "^6.0|^7.0",
-        "phpstan/phpstan-deprecation-rules": "^1.2",
         "symfony/http-kernel": "^6.1|^7.0",
         "symfony/property-info": "^6.1|^7.0",
         "symfony/serializer": "^6.1|^7.0",
@@ -21,7 +20,8 @@
         "phpstan/phpstan-webmozart-assert": "^1.2",
         "phpunit/phpunit": "^10.5",
         "roave/security-advisories": "dev-master",
-        "symfony/phpunit-bridge": "6.2.*|^7.0"
+        "symfony/phpunit-bridge": "6.2.*|^7.0",
+        "phpstan/phpstan-deprecation-rules": "^1.2"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Przenoszę do require-dev, bo przy aktualizacja phpstan'a coś się pultało i blokowało composer update. Poza tym to lokalno-testowa zależność, więc to jej miejsce.